### PR TITLE
Preserving debug symbols in non-release build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,15 +32,15 @@ ASFLAGS := -march=$(ARCH) -mabi=$(ABI) -I headers --defsym OUTPUT_DEV=$(OUTPUT_D
 CFLAGS := -march=$(ARCH) -mabi=$(ABI)  -nostdlib -static -I headers -T platforms/$(MACHINE).ld
 LDFLAGS := -Arv32$(RISC_V_EXTENSIONS) -melf32lriscv -T platforms/$(MACHINE).ld -static -nostdlib
 
-QEMU_EXTENSIONS := e=on,m=off,i=off,h=off,f=off,d=off,a=off,f=off,c=off,zawrs=off,sstc=off,zicntr=off,zihpm=off,zicboz=off,zicbom=off,svadu=off,zicsr=on,zfa=off
+QEMU_EXTENSIONS := e=on,m=on,i=off,h=off,f=off,d=off,a=off,f=off,c=off,zawrs=off,sstc=off,zicntr=off,zihpm=off,zicboz=off,zicbom=off,svadu=off,zicsr=on,zfa=off
 QEMU := qemu-system-riscv32 -machine $(MACHINE) $(QEMU_MACHINE_CONFIG) -cpu rv32,$(QEMU_EXTENSIONS) -nographic -serial mon:stdio -echr 17
 
 ifneq ($(filter release, $(MAKECMDGOALS)),)
 CFLAGS += -Os
 LDFLAGS += --gc-sections
 else
-ASFLAGS += -g -D
-CFLAGS += -g -O0 -D
+ASFLAGS += -g
+CFLAGS += -g -O0
 LDFLAGS += -g --no-gc-sections
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -29,16 +29,19 @@ RISC_V_EXTENSIONS := emzicsr
 ARCH := rv32$(RISC_V_EXTENSIONS)
 ABI := ilp32e
 ASFLAGS := -march=$(ARCH) -mabi=$(ABI) -I headers --defsym OUTPUT_DEV=$(OUTPUT_DEV) --defsym m_$(MACHINE)=1
-CFLAGS := -march=$(ARCH) -mabi=$(ABI)  -nostdlib -static -I headers -Os
-LDFLAGS := -Arv32$(RISC_V_EXTENSIONS) -melf32lriscv -T platforms/$(MACHINE).ld --gc-sections -Os -static
+CFLAGS := -march=$(ARCH) -mabi=$(ABI)  -nostdlib -static -I headers -T platforms/$(MACHINE).ld
+LDFLAGS := -Arv32$(RISC_V_EXTENSIONS) -melf32lriscv -T platforms/$(MACHINE).ld -static -nostdlib
 
-QEMU_EXTENSIONS := e=on,m=on,i=off,h=off,f=off,d=off,a=off,f=off,c=off,zawrs=off,sstc=off,zicntr=off,zihpm=off,zicboz=off,zicbom=off,svadu=off
+QEMU_EXTENSIONS := e=on,m=off,i=off,h=off,f=off,d=off,a=off,f=off,c=off,zawrs=off,sstc=off,zicntr=off,zihpm=off,zicboz=off,zicbom=off,svadu=off,zicsr=on,zfa=off
 QEMU := qemu-system-riscv32 -machine $(MACHINE) $(QEMU_MACHINE_CONFIG) -cpu rv32,$(QEMU_EXTENSIONS) -nographic -serial mon:stdio -echr 17
 
-ifneq ($(filter debug gdb debug-main gdb-main, $(MAKECMDGOALS)),)
-ASFLAGS += -g -o0
-CFLAGS += -g -o0
-LDFLAGS += -g -o0
+ifneq ($(filter release, $(MAKECMDGOALS)),)
+CFLAGS += -Os
+LDFLAGS += --gc-sections
+else
+ASFLAGS += -g -D
+CFLAGS += -g -O0 -D
+LDFLAGS += -g --no-gc-sections
 endif
 
 #----------------------------------------
@@ -79,6 +82,9 @@ $(OBJDIR)/$(OBJ): %.o: %.s | $(OBJDIR)
 compile: $(OBJ)
 
 build: compile platforms/$(MACHINE).ld
+	$(CC) $(CFLAGS) -o build/$(MACHINE).elf $(OBJ_FILES)
+
+release: compile platforms/$(MACHINE).ld
 	$(LD) $(LDFLAGS) -o build/$(MACHINE).elf $(OBJ_FILES)
 	$(TOOL)-strip --strip-all build/$(MACHINE).elf
 
@@ -91,7 +97,7 @@ $(OBJDIR)/$(TEST_C_OBJ): %.o: %.c | $(OBJDIR)
 compile-tests: $(TEST_ASM_OBJ) $(TEST_C_OBJ)
 
 $(TEST_FILES): %.elf: $(OBJDIR)/%.o
-	$(LD) $(LDFLAGS) -o build/$@ $< $(filter-out $(OBJDIR)/main.o, $(OBJ_FILES)) $(TEST_SUPPORT_OBJ)
+	$(CC) $(CFLAGS) -o build/$@ $< $(filter-out $(OBJDIR)/main.o, $(OBJ_FILES)) $(TEST_SUPPORT_OBJ)
 
 build-test: compile compile-tests test_$(TEST_NAME).elf
 
@@ -113,7 +119,7 @@ debug: build-test
 
 debug-main: build
 	@echo "Ctrl-Q C for QEMU console, then quit to exit"
-	$(QEMU) -s -S -bios build/riscvos.elf
+	$(QEMU) -s -S -bios build/$(MACHINE).elf
 
 gdb: build-test
 	gdb -ex 'target remote localhost:1234' ./build/test_$(TEST_NAME).elf

--- a/src/irq.s
+++ b/src/irq.s
@@ -221,13 +221,6 @@ handle_exception:
     ret
 
 
-fn handle_math
-    stack_alloc
-
-    stack_free
-endfn
-
-
 .type handle_ext_irq, @function
 handle_ext_irq:
     stack_alloc

--- a/src/irq.s
+++ b/src/irq.s
@@ -221,6 +221,13 @@ handle_exception:
     ret
 
 
+fn handle_math
+    stack_alloc
+
+    stack_free
+endfn
+
+
 .type handle_ext_irq, @function
 handle_ext_irq:
     stack_alloc

--- a/tests/startup.s
+++ b/tests/startup.s
@@ -1,6 +1,10 @@
+.include "config.s"
+.include "consts.s"
+.include "macros.s"
+
 .section .text.start
 
-.globl _start
+.global _start
 _start:
     .option push
     .option norelax
@@ -10,8 +14,10 @@ _start:
     la sp, __stack_top
     mv s0, sp
 
+    stack_alloc
     call sysinit
     call test_main
+    stack_free
 
 
 loop:


### PR DESCRIPTION
LD was stripping all debug symbols from the final elf file. In the result I use LD only to produce the release build, as it has more options to reduce final file's size. But the debug's elf file is created with CC