### PR TITLE
Syscall

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ hardware and memory.
 - trivial shell with five (!!!) commands: `cls`, `date`, `print`, `prompt`, `fbdump`
 - drivers for UART, RTC and PLIC
 - keyboard input (UART, interrupts)
-- system functions callable via `ecall`
+- [system functions](../wiki/System-functions) callable via `ecall`
 - interrupt/exception handlers
 - User Mode (for running shell) and Machine Mode (for the system)
 - various math and string functions

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ hardware and memory.
 ### Implemented features
 
 - framebuffer (40x25 characters text screen, configurable),
-- trivial [shell](/ddrcode/riscv-os/wiki/Shell-commands) with five (!!!) commands: `cls`, `date`, `print`, `prompt`, `fbdump`
+- trivial [shell](https://github.com/ddrcode/riscv-os/wiki/Shell-commands) with five (!!!) commands: `cls`, `date`, `print`, `prompt`, `fbdump`
 - drivers for UART, RTC and PLIC
 - keyboard input (UART, interrupts)
-- [system functions](/ddrcode/riscv-os/wiki/System-functions) callable via `ecall`
+- [system functions](https://github.com/ddrcode/riscv-os/wiki/System-functions) callable via `ecall`
 - interrupt/exception handlers
 - User Mode (for running shell) and Machine Mode (for the system)
 - various math and string functions

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ hardware and memory.
 ### Implemented features
 
 - framebuffer (40x25 characters text screen, configurable),
-- trivial shell with five (!!!) commands: `cls`, `date`, `print`, `prompt`, `fbdump`
+- trivial [shell](/ddrcode/riscv-os/wiki/Shell-commands) with five (!!!) commands: `cls`, `date`, `print`, `prompt`, `fbdump`
 - drivers for UART, RTC and PLIC
 - keyboard input (UART, interrupts)
-- [system functions](../wiki/System-functions) callable via `ecall`
+- [system functions](/ddrcode/riscv-os/wiki/System-functions) callable via `ecall`
 - interrupt/exception handlers
 - User Mode (for running shell) and Machine Mode (for the system)
 - various math and string functions

--- a/headers/config.s
+++ b/headers/config.s
@@ -2,7 +2,7 @@
 .equ __CONFIG_S__, 1
 
 # Generic
-.equ DEBUG, 1
+.equ DEBUG, 0
 
 .weak ENABLE_IRQ
 .weak ENABLE_PLIC

--- a/headers/consts.s
+++ b/headers/consts.s
@@ -3,9 +3,7 @@
 
 # System functions
 
-.equ SYS_FN_LEN, 5
-
-
+.equ SYSFN_SLEEP, 1
 .equ SYSFN_IDLE, 2
 
 # Time functions

--- a/headers/consts.s
+++ b/headers/consts.s
@@ -7,11 +7,18 @@
 
 
 .equ SYSFN_IDLE, 2
+
+# Time functions
 .equ SYSFN_GET_SECS_FROM_EPOCH, 10
 .equ SYSFN_GET_DATE, 11
 .equ SYSFN_GET_TIME, 13
 
-.equ SYSFN_LAST_FN_ID, 14
+# I/O functions
+.equ SYSFN_GET_CHAR, 20
+.equ SYSFN_PRINT_CHAR, 21
+.equ SYSFN_PRINT_STR, 22
+
+.equ SYSFN_LAST_FN_ID, 23
 
 # Error Codes
 

--- a/headers/consts.s
+++ b/headers/consts.s
@@ -7,9 +7,11 @@
 
 
 .equ SYSFN_IDLE, 2
-.equ SYSFN_GET_SEC_FROM_EPOCH, 10
+.equ SYSFN_GET_SECS_FROM_EPOCH, 10
 .equ SYSFN_GET_DATE, 11
 .equ SYSFN_GET_TIME, 13
+
+.equ SYSFN_LAST_FN_ID, 14
 
 # Error Codes
 

--- a/headers/consts.s
+++ b/headers/consts.s
@@ -6,6 +6,11 @@
 .equ SYS_FN_LEN, 5
 
 
+.equ SYSFN_IDLE, 2
+.equ SYSFN_GET_SEC_FROM_EPOCH, 10
+.equ SYSFN_GET_DATE, 11
+.equ SYSFN_GET_TIME, 13
+
 # Error Codes
 
 .equ NUM_OF_ERRORS, 6                  # number of error codes

--- a/headers/macros.s
+++ b/headers/macros.s
@@ -71,9 +71,9 @@
     .cfi_endproc
 .endm
 
-.macro global_fn, name
-    .global \name
-    fn \name
+.macro syscall, fn_id
+    li a5, \fn_id
+    ecall
 .endm
 
 .endif

--- a/headers/macros.s
+++ b/headers/macros.s
@@ -72,8 +72,15 @@
 .endm
 
 .macro syscall, fn_id
-    li a5, \fn_id
-    ecall
+   li a5, \fn_id
+   ecall
+.endm
+
+.macro addr_from_vec, vector, id_reg, res_reg
+    la \res_reg, \vector
+    slli \id_reg, \id_reg, 2
+    add \res_reg, \res_reg, \id_reg
+    lw \res_reg, (\res_reg)
 .endm
 
 .endif

--- a/src/io.s
+++ b/src/io.s
@@ -1,4 +1,12 @@
+# I/O functions, output-device aware
+# for RISC-V OS
+# author: David de Rosier
+# https://github.com/ddrcode/riscv-os
+#
+# See LICENSE file for license details.
+
 .include "macros.s"
+.include "consts.s"
 
 .global printc
 .global prints
@@ -15,7 +23,7 @@ printc:
     sb zero, 1(sp)
 
 .if OUTPUT_DEV & 0b10
-    call uart_putc
+    syscall SYSFN_PRINT_CHAR
 .endif
 
 .if OUTPUT_DEV & 1
@@ -39,7 +47,7 @@ prints:
     push a0, 8
 
 .if OUTPUT_DEV & 0b10
-    call uart_puts
+    syscall SYSFN_PRINT_STR
 .endif
 
 .if OUTPUT_DEV & 1
@@ -57,9 +65,9 @@ println:
     push a0, 8
 
 .if OUTPUT_DEV & 0b10
-    call uart_puts
+    syscall SYSFN_PRINT_STR
     li a0, '\n'
-    call uart_putc
+    syscall SYSFN_PRINT_CHAR
 .endif
 
 .if OUTPUT_DEV & 1
@@ -74,7 +82,7 @@ println:
 .type getc, @function
 getc:
     stack_alloc 4
-    call uart_getc
+    syscall SYSFN_GET_CHAR
     stack_free 4
     ret
 
@@ -100,7 +108,7 @@ read_line:
         beqz s0, 2f                    # call wfi if irqs are anbled
             # wfi                        # wait for IRQ
 2:
-        call getc
+        syscall SYSFN_GET_CHAR
         beqz a0, 1b                    # continue if no key identified
 
         li t0, 10                      # exit on \r or \n
@@ -139,11 +147,11 @@ _printc_bcksp:
 
 .if OUTPUT_DEV & 0b10
     li a0, '\b'
-    call uart_putc
+    syscall SYSFN_PRINT_CHAR
     li a0, ' '
-    call uart_putc
+    syscall SYSFN_PRINT_CHAR
     li a0, '\b'
-    call uart_putc
+    syscall SYSFN_PRINT_CHAR
 .endif
 
 .if OUTPUT_DEV & 0b10

--- a/src/irq.s
+++ b/src/irq.s
@@ -294,6 +294,16 @@ fn handle_exception_vector
 endfn
 
 
+# Handler for ecall operations from user mode
+# As i's being invoked from handle_exception_vector, it takes
+# all params from a pointer to a dump of all registers on the stack.
+# Arguments
+#     a0 - pointer to registers dump on the stack
+# Returns
+#     Whatever the system functin returns
+# TODO it can be massively simplified (no stack operations)
+#      if caught early in handle_exception_vector function
+#      and called (or even jumped into) directly
 fn handle_syscall
     stack_alloc
     push s1, 8

--- a/src/irq.s
+++ b/src/irq.s
@@ -296,10 +296,23 @@ endfn
 
 fn handle_syscall
     stack_alloc
-    mv t0, a0
-    lw a0, 40(t0)                      # fetch value of a0 (x10) from the stack
-    lw a5, 60(t0)                      # fetch value of a5 (x15) from the stack
-    call syscall
+    push s1, 8
+    mv s1, a0
+
+    lw a0, 40(s1)                      # fetch value of a0 (x10) from the stack
+    lw a1, 44(s1)                      # fetch value of a1 (x10) from the stack
+    lw a2, 48(s1)                      # fetch value of a2 (x10) from the stack
+    lw a3, 52(s1)                      # fetch value of a3 (x10) from the stack
+    lw a4, 56(s1)                      # fetch value of a4 (x10) from the stack
+    lw a5, 60(s1)                      # fetch value of a5 (x15) from the stack
+
+    call sys_call
+
+    sw a0, 40(s1)
+    sw a1, 44(s1)
+    sw a5, 60(s1)
+
+    pop s1, 8
     stack_free
     ret
 endfn
@@ -460,7 +473,7 @@ exceptions_vector:
     .word    handle_syscall            #  8: Environment call from U-mode
     .word    0                         #  9: Environment call from S-mode
     .word    0                         # 10: Reserved
-    .word    handle_syscall            # 11: Environment call from M-mode
+    .word    0                         # 11: Environment call from M-mode
     .word    handle_exception          # 12: Instruction page fault
     .word    handle_exception          # 13: Load page fault
     .word    0                         # 14: Reserved

--- a/src/shell.s
+++ b/src/shell.s
@@ -18,8 +18,7 @@
 .global show_error
 .global show_date_time
 
-.type shell_init, @function
-shell_init:
+fn shell_init
     stack_alloc
     call clear_screen
     la a0, welcome
@@ -30,9 +29,10 @@ shell_init:
     call shell_command_loop
     stack_free
     ret
+endfn
 
-.type shell_command_loop, @function
-shell_command_loop:
+
+fn shell_command_loop
     stack_alloc 64
 1:
         mv a0, sp
@@ -43,13 +43,16 @@ shell_command_loop:
             mv a0, sp
             call exec_cmd
         j 1b
+
     call panic                         # the loop should never end
     stack_free 64
     ret
+endfn
+
 
 # Arguments
 #    a0 - cmd string pointer
-exec_cmd:
+fn exec_cmd
     stack_alloc
     push a0, 8
     push zero, 4
@@ -80,6 +83,7 @@ exec_cmd:
 
     stack_free
     ret
+endfn
 
 
 # Splits string between command and argument(s).
@@ -88,7 +92,7 @@ exec_cmd:
 #    a0 - cmd string pointer
 # Returns
 #    a0 - address of arguments string (or 0 if none)
-split_cmd:
+fn split_cmd
     stack_alloc
     push a0, 8
 
@@ -102,6 +106,8 @@ split_cmd:
 1:
     stack_free
     ret
+endfn
+
 
 # Parses command line
 # Arguments:
@@ -110,22 +116,19 @@ split_cmd:
 #     a0 - system function id (or 0 when not found)
 #     a5 - error code
 # TODO make index byte not word
-parse_cmd:
+fn parse_cmd
     stack_alloc
+    push s1, 0
 
     la a1, commands
-    li a2, SYS_FN_LEN
+    mv s1, zero
 
     push a0, 8
-    push a2, 0
 1:                                   # do
         push a1, 4
         call strcmp
         bgtz a0, 2f                  # finish when command matches
-            pop a2, 0                # retrieve index from the stack
-            dec a2                   # decrement index
-            beqz a2, 3f              # finnish if index is 0
-            push a2, 0
+            inc s1                   # increment index
 
             pop a1, 4                # retrieve array pointer from the stack
             mv a0, a1
@@ -133,26 +136,28 @@ parse_cmd:
             pop a1, 4
             add a1, a1, a0           # Move array pointer to the next item
             inc a1
+            lbu t2, (a1)
+            beqz t2, 3f              # finish if the next item is 0
             pop a0, 8                # retrieve command pointer from the stack
     j 1b
 2:                                   # cmd found
-    li t0, SYS_FN_LEN                # retrieve num of commands
-    sub a0, t0, a2                   # fn_no = (no_of_comands - index) + 1
-    inc a0
+    addi a0, s1, 1
     setz a5
     j 4f
 3:                                   # cmd not found
     setz a0
     li a5, ERR_CMD_NOT_FOUND
 4:                                   # end
+    pop s1, 0
     stack_free
     ret
+endfn
 
 
 # Shows error
 # Arguments:
 #     a0 - error code
-show_error:
+fn show_error
     stack_alloc 4
     li t0, NUM_OF_ERRORS
     blt a0, t0, 1f                     # jump if valid error code
@@ -167,9 +172,10 @@ show_error:
     setz a5
     stack_free 4
     ret
+endfn
 
 
-show_date_time:
+fn show_date_time
     stack_alloc 32
 
     syscall SYSFN_GET_SECS_FROM_EPOCH
@@ -184,11 +190,13 @@ show_date_time:
 1:
     stack_free 32
     ret
+endfn
+
 
 # Set single-character prompt
 # arguments:
 #    a0 - pointer to prompt string (only the first char will be taken)
-set_prompt:
+fn set_prompt
     beqz a0, 1f
     la t0, prompt
     lbu t1, (a0)
@@ -199,6 +207,7 @@ set_prompt:
 1:
     li a5, 2                           # set error code
 2:  ret
+endfn
 
 
 #----------------------------------------
@@ -241,3 +250,4 @@ shell_cmd_vector:
         .word set_prompt
         .word println
         .word print_screen
+        .word 0

--- a/src/sysfn.s
+++ b/src/sysfn.s
@@ -14,7 +14,7 @@
 
 .section .text
 
-fn get_secs_from_epoch
+fn sysfn_get_secs_from_epoch
 .ifdef RTC_BASE
     stack_alloc
     call rtc_time_in_sec
@@ -23,6 +23,30 @@ fn get_secs_from_epoch
 .else
     li a5, ERR_NOT_SUPPORTED
 .endif
+    ret
+endfn
+
+
+fn sysfn_get_date
+    stack_alloc
+    call sysfn_get_secs_from_epoch
+    bnez a5, 1f
+    call get_date
+    mv a5, zero
+1:
+    stack_free
+    ret
+endfn
+
+
+fn sysfn_get_time
+    stack_alloc
+    call sysfn_get_secs_from_epoch
+    bnez a5, 1f
+    call get_time
+    mv a5, zero
+1:
+    stack_free
     ret
 endfn
 
@@ -42,10 +66,10 @@ sysfn_vector:
     .word    0                         # 7
     .word    0                         # 8
     .word    0                         # 9
-    .word    get_secs_from_epoch       # 10
-    .word    0                         # 11
+    .word    sysfn_get_secs_from_epoch # 10
+    .word    sysfn_get_date            # 11
     .word    0                         # 12
-    .word    0                         # 13
+    .word    sysfn_get_time            # 13
     .word    0                         # 14
     .word    0                         # 15
     .word    0                         # 16

--- a/src/sysfn.s
+++ b/src/sysfn.s
@@ -1,0 +1,45 @@
+# System function
+# author: David de Rosier
+# https://github.com/ddrcode/riscv-os
+#
+# See LICENSE file for license details.
+
+.include "macros.s"
+.include "consts.s"
+.include "config.s"
+
+.global sysfn_vector
+
+#----------------------------------------
+
+.section .text
+
+fn get_secs_from_epoch
+.ifdef RTC_BASE
+    stack_alloc
+    call rtc_time_in_sec
+    setz a5
+    stack_free
+.else
+    li a5, ERR_NOT_SUPPORTED
+.endif
+    ret
+endfn
+
+#----------------------------------------
+
+
+.section .data
+
+sysfn_vector:
+    .word    0                         # 0
+    .word    0                         # 1
+    .word    0                         # 2
+    .word    0                         # 3
+    .word    0                         # 4
+    .word    0                         # 5
+    .word    0                         # 6
+    .word    0                         # 7
+    .word    0                         # 8
+    .word    0                         # 9
+    .word    get_secs_from_epoch       # 10

--- a/src/sysfn.s
+++ b/src/sysfn.s
@@ -43,3 +43,15 @@ sysfn_vector:
     .word    0                         # 8
     .word    0                         # 9
     .word    get_secs_from_epoch       # 10
+    .word    0                         # 11
+    .word    0                         # 12
+    .word    0                         # 13
+    .word    0                         # 14
+    .word    0                         # 15
+    .word    0                         # 16
+    .word    0                         # 17
+    .word    0                         # 18
+    .word    0                         # 19
+    .word    uart_getc                 # 20
+    .word    uart_putc                 # 21
+    .word    uart_puts                 # 22

--- a/tests/startup.s
+++ b/tests/startup.s
@@ -21,8 +21,18 @@ _start:
     csrc mie, t0                       # but disable system timer and hw irqs
 
     call sysinit
-    call test_main
+
+    # Run test in user mode
+
+    la t0, test_main
+    csrw mepc, t0
+
+    li t0, 0b11                        # set PCP field of mstatus to 00 (User mode)
+    slli t0, t0, 11
+    csrc mstatus, t0
+
     stack_free
+    mret
 
 
 loop:


### PR DESCRIPTION
- fixes #48 
- syscall macro
- consts with system functions names
- uart and rtc function calls replaced with syscalls
- improved cmd parsing function
- separate vectors with system functions and shell commands