### PR TITLE
PMP for entire memory range

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ LDFLAGS := -Arv32$(RISC_V_EXTENSIONS) -melf32lriscv -T platforms/$(MACHINE).ld -
 
 QEMU_EXTENSIONS := e=on,m=on,i=off,h=off,f=off,d=off,a=off,f=off,c=off,zawrs=off,sstc=off,zicntr=off,zihpm=off,zicboz=off,zicbom=off,svadu=off,zicsr=on,zfa=off,zmmul=off
 QEMU := qemu-system-riscv32 -machine $(MACHINE) -bios none \
-		-cpu rv32,pmp=false,$(QEMU_EXTENSIONS) -nographic -echr 17 \
+		-cpu rv32,pmp=true,$(QEMU_EXTENSIONS) -nographic -echr 17 \
         -serial mon:stdio -serial file:riscv-os.log
 
 ifdef DRIVE

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ make run DRIVE=apps/disc.tar
 
 Optionally each command can be provided with `MACHINE` attribute, i.e.
 `make run start MACHINE=sifive_u`. Currently, the available machines are
-`virt` (default) and `sifive_e` (`sifive_u` in progress).
+`virt` (default) and `sifive_e` and `sifive_u`.
 
 The QEMU-related targets (like `make run`) accept optional `DRIVE` argument,
 that can be loaded to `flash1.rom` on virt device. If done so then the `run` command

--- a/headers/consts.s
+++ b/headers/consts.s
@@ -49,6 +49,7 @@
 .equ CFG_STD_IN, 8
 .equ CFG_STD_ERR, 12
 .equ CFG_STD_DEBUG, 16
+.equ CFG_PLATFORM_NAME, 20
 
 
 # HAL

--- a/headers/platforms/config-sifive_e.s
+++ b/headers/platforms/config-sifive_e.s
@@ -9,10 +9,10 @@
 
 # Devices
 .equ UART_0_BASE, 0x10013000
-.equ UART_0_IRQ, 10 # TBC!
+.equ UART_0_IRQ, 3 # Based on Qemu sources
 
 .equ UART_1_BASE, 0x10023000
-.equ UART_1_IRQ, 11 # TBC!
+.equ UART_1_IRQ, 4 # Based on Qemu sources
 
 .equ PLIC_BASE, 0xc000000
 

--- a/headers/platforms/config-sifive_u.s
+++ b/headers/platforms/config-sifive_u.s
@@ -9,8 +9,11 @@
 .equ SCREEN_HEIGHT, 25
 
 # Devices
-.equ UART0_BASE, 0x10010000
-.equ UART0_IRQ, 4
+.equ UART_0_BASE, 0x10010000
+.equ UART_0_IRQ, 4
+
+.equ UART_1_BASE, 0x10011000
+.equ UART_1_IRQ, 5
 
 .equ PLIC_BASE, 0xc000000
 

--- a/platforms/sifive_u.dts
+++ b/platforms/sifive_u.dts
@@ -1,0 +1,246 @@
+/dts-v1/;
+
+/ {
+	#address-cells = <0x02>;
+	#size-cells = <0x02>;
+	compatible = "sifive,hifive-unleashed-a00";
+	model = "SiFive HiFive Unleashed A00";
+
+	chosen {
+		stdout-path = "/soc/serial@10010000";
+	};
+
+	aliases {
+		serial0 = "/soc/serial@10010000";
+		serial1 = "/soc/serial@10011000";
+		ethernet0 = "/soc/ethernet@10090000";
+	};
+
+	gpio-restart {
+		compatible = "gpio-restart";
+		gpios = <0x07 0x0a 0x01>;
+	};
+
+	cpus {
+		#address-cells = <0x01>;
+		#size-cells = <0x00>;
+		timebase-frequency = <0xf4240>;
+
+		cpu@0 {
+			device_type = "cpu";
+			reg = <0x00>;
+			status = "okay";
+			compatible = "riscv";
+			riscv,isa-extensions = "i", "m", "a", "c", "zicntr", "zicsr", "zifencei", "zihpm";
+			riscv,isa-base = "rv32i";
+			riscv,isa = "rv32imac_zicntr_zicsr_zifencei_zihpm";
+
+			interrupt-controller {
+				#interrupt-cells = <0x01>;
+				interrupt-controller;
+				compatible = "riscv,cpu-intc";
+				phandle = <0x04>;
+			};
+		};
+
+		cpu@1 {
+			device_type = "cpu";
+			reg = <0x01>;
+			status = "okay";
+			compatible = "riscv";
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "zicntr", "zicsr", "zifencei", "zihpm";
+			riscv,isa-base = "rv32i";
+			riscv,isa = "rv32imafdc_zicntr_zicsr_zifencei_zihpm";
+			mmu-type = "riscv,sv32";
+
+			interrupt-controller {
+				#interrupt-cells = <0x01>;
+				interrupt-controller;
+				compatible = "riscv,cpu-intc";
+				phandle = <0x03>;
+			};
+		};
+	};
+
+	memory@80000000 {
+		device_type = "memory";
+		reg = <0x00 0x80000000 0x00 0x8000000>;
+	};
+
+	rtcclk {
+		#clock-cells = <0x00>;
+		compatible = "fixed-clock";
+		clock-frequency = <0xf4240>;
+		clock-output-names = "rtcclk";
+		phandle = <0x02>;
+	};
+
+	hfclk {
+		#clock-cells = <0x00>;
+		compatible = "fixed-clock";
+		clock-frequency = <0x1fca055>;
+		clock-output-names = "hfclk";
+		phandle = <0x01>;
+	};
+
+	soc {
+		#address-cells = <0x02>;
+		#size-cells = <0x02>;
+		compatible = "simple-bus";
+		ranges;
+
+		serial@10010000 {
+			interrupts = <0x04>;
+			interrupt-parent = <0x06>;
+			clocks = <0x05 0x03>;
+			reg = <0x00 0x10010000 0x00 0x1000>;
+			compatible = "sifive,uart0";
+		};
+
+		serial@10011000 {
+			interrupts = <0x05>;
+			interrupt-parent = <0x06>;
+			clocks = <0x05 0x03>;
+			reg = <0x00 0x10011000 0x00 0x1000>;
+			compatible = "sifive,uart0";
+		};
+
+		pwm@10021000 {
+			#pwm-cells = <0x00>;
+			clocks = <0x05 0x03>;
+			interrupts = <0x2e 0x2f 0x30 0x31>;
+			interrupt-parent = <0x06>;
+			reg = <0x00 0x10021000 0x00 0x1000>;
+			compatible = "sifive,pwm0";
+		};
+
+		pwm@10020000 {
+			#pwm-cells = <0x00>;
+			clocks = <0x05 0x03>;
+			interrupts = <0x2a 0x2b 0x2c 0x2d>;
+			interrupt-parent = <0x06>;
+			reg = <0x00 0x10020000 0x00 0x1000>;
+			compatible = "sifive,pwm0";
+		};
+
+		ethernet@10090000 {
+			#size-cells = <0x00>;
+			#address-cells = <0x01>;
+			local-mac-address = [52 54 00 12 34 56];
+			clock-names = "pclk", "hclk";
+			clocks = <0x05 0x02 0x05 0x02>;
+			interrupts = <0x35>;
+			interrupt-parent = <0x06>;
+			phy-handle = <0x08>;
+			phy-mode = "gmii";
+			reg-names = "control";
+			reg = <0x00 0x10090000 0x00 0x2000 0x00 0x100a0000 0x00 0x1000>;
+			compatible = "sifive,fu540-c000-gem";
+
+			ethernet-phy@0 {
+				reg = <0x00>;
+				phandle = <0x08>;
+			};
+		};
+
+		spi@10040000 {
+			compatible = "sifive,spi0";
+			reg = <0x00 0x10040000 0x00 0x1000>;
+			interrupt-parent = <0x06>;
+			interrupts = <0x33>;
+			clocks = <0x05 0x03>;
+			#address-cells = <0x01>;
+			#size-cells = <0x00>;
+
+			flash@0 {
+				compatible = "jedec,spi-nor";
+				reg = <0x00>;
+				spi-max-frequency = <0x2faf080>;
+				m25p,fast-read;
+				spi-tx-bus-width = <0x04>;
+				spi-rx-bus-width = <0x04>;
+			};
+		};
+
+		spi@10050000 {
+			compatible = "sifive,spi0";
+			reg = <0x00 0x10050000 0x00 0x1000>;
+			interrupt-parent = <0x06>;
+			interrupts = <0x06>;
+			clocks = <0x05 0x03>;
+			#address-cells = <0x01>;
+			#size-cells = <0x00>;
+
+			mmc@0 {
+				compatible = "mmc-spi-slot";
+				reg = <0x00>;
+				spi-max-frequency = <0x1312d00>;
+				voltage-ranges = <0xce4 0xce4>;
+				disable-wp;
+			};
+		};
+
+		cache-controller@2010000 {
+			compatible = "sifive,fu540-c000-ccache";
+			cache-block-size = <0x40>;
+			cache-level = <0x02>;
+			cache-sets = <0x400>;
+			cache-size = <0x200000>;
+			cache-unified;
+			interrupt-parent = <0x06>;
+			interrupts = <0x01 0x02 0x03>;
+			reg = <0x00 0x2010000 0x00 0x1000>;
+		};
+
+		dma@3000000 {
+			compatible = "sifive,fu540-c000-pdma";
+			reg = <0x00 0x3000000 0x00 0x100000>;
+			interrupt-parent = <0x06>;
+			interrupts = <0x17 0x18 0x19 0x1a 0x1b 0x1c 0x1d 0x1e>;
+			#dma-cells = <0x01>;
+		};
+
+		gpio@10060000 {
+			compatible = "sifive,gpio0";
+			interrupt-parent = <0x06>;
+			interrupts = <0x07 0x08 0x09 0x0a 0x0b 0x0c 0x0d 0x0e 0x0f 0x10 0x11 0x12 0x13 0x14 0x15 0x16>;
+			reg = <0x00 0x10060000 0x00 0x1000>;
+			gpio-controller;
+			#gpio-cells = <0x02>;
+			interrupt-controller;
+			#interrupt-cells = <0x02>;
+			clocks = <0x05 0x03>;
+			phandle = <0x07>;
+		};
+
+		interrupt-controller@c000000 {
+			phandle = <0x06>;
+			riscv,ndev = <0x35>;
+			reg = <0x00 0xc000000 0x00 0x4000000>;
+			interrupts-extended = <0x04 0x0b 0x03 0x0b 0x03 0x09>;
+			interrupt-controller;
+			compatible = "sifive,plic-1.0.0", "riscv,plic0";
+			#interrupt-cells = <0x01>;
+		};
+
+		clock-controller@10000000 {
+			compatible = "sifive,fu540-c000-prci";
+			reg = <0x00 0x10000000 0x00 0x1000>;
+			clocks = <0x01 0x02>;
+			#clock-cells = <0x01>;
+			phandle = <0x05>;
+		};
+
+		otp@10070000 {
+			compatible = "sifive,fu540-c000-otp";
+			reg = <0x00 0x10070000 0x00 0x1000>;
+			fuse-count = <0x1000>;
+		};
+
+		clint@2000000 {
+			interrupts-extended = <0x04 0x03 0x04 0x07 0x03 0x03 0x03 0x07>;
+			reg = <0x00 0x2000000 0x00 0x10000>;
+			compatible = "sifive,clint0", "riscv,clint0";
+		};
+	};
+};

--- a/platforms/virt.dts
+++ b/platforms/virt.dts
@@ -1,0 +1,211 @@
+/dts-v1/;
+
+/ {
+	#address-cells = <0x02>;
+	#size-cells = <0x02>;
+	compatible = "riscv-virtio";
+	model = "riscv-virtio,qemu";
+
+	poweroff {
+		value = <0x5555>;
+		offset = <0x00>;
+		regmap = <0x04>;
+		compatible = "syscon-poweroff";
+	};
+
+	reboot {
+		value = <0x7777>;
+		offset = <0x00>;
+		regmap = <0x04>;
+		compatible = "syscon-reboot";
+	};
+
+	platform-bus@4000000 {
+		interrupt-parent = <0x03>;
+		ranges = <0x00 0x00 0x4000000 0x2000000>;
+		#address-cells = <0x01>;
+		#size-cells = <0x01>;
+		compatible = "qemu,platform", "simple-bus";
+	};
+
+	memory@80000000 {
+		device_type = "memory";
+		reg = <0x00 0x80000000 0x00 0x8000000>;
+	};
+
+	cpus {
+		#address-cells = <0x01>;
+		#size-cells = <0x00>;
+		timebase-frequency = <0x989680>;
+
+		cpu@0 {
+			phandle = <0x01>;
+			device_type = "cpu";
+			reg = <0x00>;
+			status = "okay";
+			compatible = "riscv";
+			riscv,cbop-block-size = <0x40>;
+			riscv,cboz-block-size = <0x40>;
+			riscv,cbom-block-size = <0x40>;
+			riscv,isa-extensions = "i", "m", "a", "f", "d", "c", "h", "zic64b", "zicbom", "zicbop", "zicboz", "ziccamoa", "ziccif", "zicclsm", "ziccrse", "zicntr", "zicsr", "zifencei", "zihintntl", "zihintpause", "zihpm", "zmmul", "za64rs", "zaamo", "zalrsc", "zawrs", "zfa", "zca", "zcf", "zcd", "zba", "zbb", "zbc", "zbs", "ssccptr", "sscounterenw", "sstc", "sstvala", "sstvecd", "svadu", "svvptc";
+			riscv,isa-base = "rv32i";
+			riscv,isa = "rv32imafdch_zic64b_zicbom_zicbop_zicboz_ziccamoa_ziccif_zicclsm_ziccrse_zicntr_zicsr_zifencei_zihintntl_zihintpause_zihpm_zmmul_za64rs_zaamo_zalrsc_zawrs_zfa_zca_zcf_zcd_zba_zbb_zbc_zbs_ssccptr_sscounterenw_sstc_sstvala_sstvecd_svadu_svvptc";
+			mmu-type = "riscv,sv32";
+
+			interrupt-controller {
+				#interrupt-cells = <0x01>;
+				interrupt-controller;
+				compatible = "riscv,cpu-intc";
+				phandle = <0x02>;
+			};
+		};
+
+		cpu-map {
+
+			cluster0 {
+
+				core0 {
+					cpu = <0x01>;
+				};
+			};
+		};
+	};
+
+	pmu {
+		riscv,event-to-mhpmcounters = <0x01 0x01 0x7fff9 0x02 0x02 0x7fffc 0x10019 0x10019 0x7fff8 0x1001b 0x1001b 0x7fff8 0x10021 0x10021 0x7fff8>;
+		compatible = "riscv,pmu";
+	};
+
+	fw-cfg@10100000 {
+		dma-coherent;
+		reg = <0x00 0x10100000 0x00 0x18>;
+		compatible = "qemu,fw-cfg-mmio";
+	};
+
+	flash@20000000 {
+		bank-width = <0x04>;
+		reg = <0x00 0x20000000 0x00 0x2000000 0x00 0x22000000 0x00 0x2000000>;
+		compatible = "cfi-flash";
+	};
+
+	chosen {
+		stdout-path = "/soc/serial@10000000";
+		rng-seed = <0x4cfb7ff0 0xec1b3a64 0xa2ac27ed 0x75a80353 0x76171e9a 0x1d592d22 0x221fb1e9 0x99333f18>;
+	};
+
+	soc {
+		#address-cells = <0x02>;
+		#size-cells = <0x02>;
+		compatible = "simple-bus";
+		ranges;
+
+		rtc@101000 {
+			interrupts = <0x0b>;
+			interrupt-parent = <0x03>;
+			reg = <0x00 0x101000 0x00 0x1000>;
+			compatible = "google,goldfish-rtc";
+		};
+
+		serial@10000000 {
+			interrupts = <0x0a>;
+			interrupt-parent = <0x03>;
+			clock-frequency = "", "8@";
+			reg = <0x00 0x10000000 0x00 0x100>;
+			compatible = "ns16550a";
+		};
+
+		test@100000 {
+			phandle = <0x04>;
+			reg = <0x00 0x100000 0x00 0x1000>;
+			compatible = "sifive,test1", "sifive,test0", "syscon";
+		};
+
+		virtio_mmio@10008000 {
+			interrupts = <0x08>;
+			interrupt-parent = <0x03>;
+			reg = <0x00 0x10008000 0x00 0x1000>;
+			compatible = "virtio,mmio";
+		};
+
+		virtio_mmio@10007000 {
+			interrupts = <0x07>;
+			interrupt-parent = <0x03>;
+			reg = <0x00 0x10007000 0x00 0x1000>;
+			compatible = "virtio,mmio";
+		};
+
+		virtio_mmio@10006000 {
+			interrupts = <0x06>;
+			interrupt-parent = <0x03>;
+			reg = <0x00 0x10006000 0x00 0x1000>;
+			compatible = "virtio,mmio";
+		};
+
+		virtio_mmio@10005000 {
+			interrupts = <0x05>;
+			interrupt-parent = <0x03>;
+			reg = <0x00 0x10005000 0x00 0x1000>;
+			compatible = "virtio,mmio";
+		};
+
+		virtio_mmio@10004000 {
+			interrupts = <0x04>;
+			interrupt-parent = <0x03>;
+			reg = <0x00 0x10004000 0x00 0x1000>;
+			compatible = "virtio,mmio";
+		};
+
+		virtio_mmio@10003000 {
+			interrupts = <0x03>;
+			interrupt-parent = <0x03>;
+			reg = <0x00 0x10003000 0x00 0x1000>;
+			compatible = "virtio,mmio";
+		};
+
+		virtio_mmio@10002000 {
+			interrupts = <0x02>;
+			interrupt-parent = <0x03>;
+			reg = <0x00 0x10002000 0x00 0x1000>;
+			compatible = "virtio,mmio";
+		};
+
+		virtio_mmio@10001000 {
+			interrupts = <0x01>;
+			interrupt-parent = <0x03>;
+			reg = <0x00 0x10001000 0x00 0x1000>;
+			compatible = "virtio,mmio";
+		};
+
+		plic@c000000 {
+			phandle = <0x03>;
+			riscv,ndev = <0x5f>;
+			reg = <0x00 0xc000000 0x00 0x600000>;
+			interrupts-extended = <0x02 0x0b 0x02 0x09>;
+			interrupt-controller;
+			compatible = "sifive,plic-1.0.0", "riscv,plic0";
+			#address-cells = <0x00>;
+			#interrupt-cells = <0x01>;
+		};
+
+		clint@2000000 {
+			interrupts-extended = <0x02 0x03 0x02 0x07>;
+			reg = <0x00 0x2000000 0x00 0x10000>;
+			compatible = "sifive,clint0", "riscv,clint0";
+		};
+
+		pci@30000000 {
+			interrupt-map-mask = <0x1800 0x00 0x00 0x07>;
+			interrupt-map = <0x00 0x00 0x00 0x01 0x03 0x20 0x00 0x00 0x00 0x02 0x03 0x21 0x00 0x00 0x00 0x03 0x03 0x22 0x00 0x00 0x00 0x04 0x03 0x23 0x800 0x00 0x00 0x01 0x03 0x21 0x800 0x00 0x00 0x02 0x03 0x22 0x800 0x00 0x00 0x03 0x03 0x23 0x800 0x00 0x00 0x04 0x03 0x20 0x1000 0x00 0x00 0x01 0x03 0x22 0x1000 0x00 0x00 0x02 0x03 0x23 0x1000 0x00 0x00 0x03 0x03 0x20 0x1000 0x00 0x00 0x04 0x03 0x21 0x1800 0x00 0x00 0x01 0x03 0x23 0x1800 0x00 0x00 0x02 0x03 0x20 0x1800 0x00 0x00 0x03 0x03 0x21 0x1800 0x00 0x00 0x04 0x03 0x22>;
+			ranges = <0x1000000 0x00 0x00 0x00 0x3000000 0x00 0x10000 0x2000000 0x00 0x40000000 0x00 0x40000000 0x00 0x40000000 0x3000000 0x03 0x00 0x03 0x00 0x01 0x00>;
+			reg = <0x00 0x30000000 0x00 0x10000000>;
+			dma-coherent;
+			bus-range = <0x00 0xff>;
+			linux,pci-domain = <0x00>;
+			device_type = "pci";
+			compatible = "pci-host-ecam-generic";
+			#size-cells = <0x02>;
+			#interrupt-cells = <0x01>;
+			#address-cells = <0x03>;
+		};
+	};
+};

--- a/shell.nix
+++ b/shell.nix
@@ -9,6 +9,7 @@ in
       qemu
       minicom
       ccls
+      dtc
     ] ++ optionals isLinux [
       gdb
     ];

--- a/src/hal/uart.s
+++ b/src/hal/uart.s
@@ -18,6 +18,7 @@
 .global uart_putc
 .global uart_puts
 .global uart_getc
+.global uart_handle_irq
 
 
 .section .text
@@ -105,6 +106,14 @@ fn uart_set_config
     lw t1, 12(t0)
     jalr t1
     stack_free
+    ret
+endfn
+
+
+fn uart_handle_irq
+    # nothing to do here, as the IRQ's are handled directly
+    # by UART drivers, however the handler must exist
+    # as otherwise there is unhandled IRQ error
     ret
 endfn
 

--- a/src/platforms/sifive_e.s
+++ b/src/platforms/sifive_e.s
@@ -44,15 +44,12 @@ fn platform_start
     add_device DEV_UART_0, drv_uart_0  # add devices to device manager
     add_device DEV_UART_1, drv_uart_1
 
+
+    la s1, platform_name
+    call_cfg_set CFG_PLATFORM_NAME, s1
+
     pop s1, 8
     stack_free
-    ret
-endfn
-
-fn handle_uart_irq
-    # nothing to do here, as the IRQ's are handled directly
-    # by the UART's driver, however the handler must exist
-    # as otherwise there is unhandled IRQ error
     ret
 endfn
 
@@ -66,8 +63,8 @@ external_irq_vector:
     .word    0                         # IRQ  0
     .word    0                         # IRQ  1
     .word    0                         # IRQ  2
-    .word    0                         # IRQ  3
-    .word    0                         # IRQ  4
+    .word    uart_handle_irq           # IRQ  3
+    .word    uart_handle_irq           # IRQ  4
     .word    0                         # IRQ  5
     .word    0                         # IRQ  6
     .word    0                         # IRQ  7
@@ -84,3 +81,9 @@ external_irq_vector:
 drv_uart_0: .space DRV_UART_STRUCT_SIZE, 0
 drv_uart_1: .space DRV_UART_STRUCT_SIZE, 0
 
+
+#----------------------------------------
+
+.section .rodata
+
+platform_name: .string "sifive_e"

--- a/src/platforms/sifive_u.s
+++ b/src/platforms/sifive_u.s
@@ -22,28 +22,39 @@ fn platform_start
     call plic_init
 
     la a0, drv_uart_0                  # Configure UART0
-    mv s1, a0
-    li a1, UART0_BASE
+    li a1, UART_0_BASE
     li a2, 0b01
-    li a3, UART0_IRQ
+    li a3, UART_0_IRQ
     call sifive_uart_init
+    mv s1, a0
 
     call_cfg_set CFG_STD_OUT, s1
     call_cfg_set CFG_STD_IN, s1
     call_cfg_set CFG_STD_ERR, s1
+
+
+    la a0, drv_uart_1                  # Configure UART1
+    li a1, UART_1_BASE
+    li a2, 0b01
+    li a3, UART_1_IRQ
+    call sifive_uart_init
+    mv s1, a0
+
     call_cfg_set CFG_STD_DEBUG, s1
+
+
+    add_device DEV_UART_0, drv_uart_0  # add devices to device manager
+    add_device DEV_UART_1, drv_uart_1
+
+
+    la s1, platform_name
+    call_cfg_set CFG_PLATFORM_NAME, s1
 
     pop s1, 8
     stack_free
     ret
 endfn
 
-fn handle_uart_irq
-    # nothing to do here, as the IRQ's are handled directly
-    # by the UART's driver, however the handler must exist
-    # as otherwise there is unhandled IRQ error
-    ret
-endfn
 
 
 #----------------------------------------
@@ -56,8 +67,8 @@ external_irq_vector:
     .word    0                         # IRQ  1
     .word    0                         # IRQ  2
     .word    0                         # IRQ  3
-    .word    handle_uart_irq           # IRQ  4
-    .word    0                         # IRQ  5
+    .word    uart_handle_irq           # IRQ  4
+    .word    uart_handle_irq           # IRQ  5
     .word    0                         # IRQ  6
     .word    0                         # IRQ  7
     .word    0                         # IRQ  8
@@ -73,3 +84,9 @@ external_irq_vector:
 drv_uart_0: .space DRV_UART_STRUCT_SIZE, 0
 drv_uart_1: .space DRV_UART_STRUCT_SIZE, 0
 
+
+#----------------------------------------
+
+.section .rodata
+
+platform_name: .string "sifive_u"

--- a/src/platforms/virt.s
+++ b/src/platforms/virt.s
@@ -11,7 +11,6 @@
 .global platform_start
 .global external_irq_vector
 
-
 #----------------------------------------
 
 .section .text.platform
@@ -35,29 +34,28 @@ fn platform_start
     call_cfg_set CFG_STD_ERR, s1
     call_cfg_set CFG_STD_DEBUG, s1
 
-    la a0, drv_rtc_0
+
+    la a0, drv_rtc_0                   # configure GoldFish RTV
     li a1, RTC_BASE
     call goldfish_rtc_init
 
-    add_device DEV_UART_0, drv_uart_0
+
+    add_device DEV_UART_0, drv_uart_0  # add devices to device managet
     add_device DEV_RTC_0, drv_rtc_0
+
+
+    la s1, platform_name
+    call_cfg_set CFG_PLATFORM_NAME, s1
 
     pop s1, 8
     stack_free
     ret
 endfn
 
-fn handle_uart_irq
-    # nothing to do here, as the IRQ's are handled directly
-    # by the UART's driver, however the handler must exist
-    # as otherwise there is unhandled IRQ error
-    ret
-endfn
-
 
 #----------------------------------------
 
-.section .data.platform
+.section .data
 
 # This is platform / machine - specific
 # Provided devices are TBC
@@ -73,7 +71,7 @@ external_irq_vector:
     .word    0 /* console device */    # IRQ  7
     .word    0 /* RNG - random nums */ # IRQ  8
     .word    0 /* balloon device */    # IRQ  9
-    .word    handle_uart_irq           # IRQ 10 (UART 0)
+    .word    uart_handle_irq           # IRQ 10 (UART 0)
     .word    0 /* ? */                 # IRQ 11
     .word    0 /* PCIE Root Port */    # IRQ 12
     .word    0 /* RTC */               # IRQ 13
@@ -81,9 +79,12 @@ external_irq_vector:
     .word    0 /* reserved */          # IRQ 15
 
 
-#----------------------------------------
-
-.section .data
-
 drv_uart_0:    .space DRV_UART_STRUCT_SIZE, 0
 drv_rtc_0:     .space DRV_RTC_STRUCT_SIZE, 0
+
+
+#----------------------------------------
+
+.section .rodata
+
+platform_name: .string "virt"

--- a/src/shell.s
+++ b/src/shell.s
@@ -14,7 +14,6 @@
 .global shell_init
 .global shell_command_loop
 .global exec_cmd
-.global set_prompt
 .global show_error
 .global show_date_time
 
@@ -200,7 +199,7 @@ endfn
 # Set single-character prompt
 # arguments:
 #    a0 - pointer to prompt string (only the first char will be taken)
-fn set_prompt
+fn cmd_set_prompt
     beqz a0, 1f
     la t0, prompt
     lbu t1, (a0)
@@ -233,6 +232,26 @@ fn run_prog
     ret
 endfn
 
+
+fn cmd_print
+    stack_alloc
+    call println
+    mv a5, zero
+    stack_free
+    ret
+endfn
+
+
+fn cmd_platform
+    stack_alloc
+    li a0, CFG_PLATFORM_NAME
+    call cfg_get
+    call println
+    mv a5, zero
+    stack_free
+    ret
+endfn
+
 #----------------------------------------
 
 .section .data
@@ -249,6 +268,7 @@ welcome: .string "Welcome to RISC-V OS v0.1"
 commands: .string "cls"
           .string "prompt"
           .string "print"
+          .string "platform"
 
 err_unknown: .string "Unknown error"
 err_not_found: .string "Command not found"
@@ -267,6 +287,7 @@ errors: .word err_unknown
 shell_cmd_vector:
         .word show_error
         .word clear_screen
-        .word set_prompt
-        .word println
+        .word cmd_set_prompt
+        .word cmd_print
+        .word cmd_platform
         .word 0

--- a/src/sysconfig.s
+++ b/src/sysconfig.s
@@ -46,3 +46,11 @@ std_out:        .word      0
 std_in:         .word      0
 std_err:        .word      0
 std_debug:      .word      0
+platform_name:  .word      default_platform_name
+
+
+#----------------------------------------
+
+.section .rodata
+
+default_platform_name: .string "unknown"

--- a/src/system.s
+++ b/src/system.s
@@ -18,7 +18,10 @@
 #------------------------------------------------------------------------------
 
 fn sysinit
-    stack_alloc 4
+    stack_alloc
+
+    call setup_pmp
+
     li a0, INFO_OUTPUT_DEV
     li a1, OUTPUT_DEV
     call cfg_set
@@ -27,7 +30,23 @@ fn sysinit
     call video_init
 .endif
 
-    stack_free 4
+    stack_free
+    ret
+endfn
+
+
+# Setup phisical memory protection (PMP)
+# At this stage it just enables it, but doesn't provide any restrictions
+# means it gives permision to the entire memory range (0xffffffff).
+# That allows to run QEMU with pmp enabled and make run the OS on machines
+# that by default disable any access to memory in User mode (like sifive_u)
+fn setup_pmp
+    not t0, zero                       # cover entore 32-bit memory range
+    csrw pmpaddr0, t0
+
+    li t0, 0b1111                      # (R | W | X | TOR mode)
+    csrw pmpcfg0, t0                   # save permissions
+
     ret
 endfn
 
@@ -39,13 +58,13 @@ endfn
 fn sys_call
     stack_alloc 4
     li t0, SYSFN_LAST_FN_ID
-    bgt a5, t0, 1f                       # error if fn id is too big
-    blez a5, 1f                          # error if fn id <= 0
+    bgt a5, t0, 1f                     # error if fn id is too big
+    blez a5, 1f                        # error if fn id <= 0
 
-    addr_from_vec sysfn_vector, a5, t0   # fetch function address from vector
-    beqz t0, 1f                          # error if fn not found (addr 0)
+    addr_from_vec sysfn_vector, a5, t0 # fetch function address from vector
+    beqz t0, 1f                        # error if fn not found (addr 0)
 
-        jalr t0                          # execute system function
+        jalr t0                        # execute system function
         j 2f
 
 1:  # error handling


### PR DESCRIPTION
- enabled PMP with full access rights to the entire memory range (closes #71 )
- that fixed the issues with sifive_u machine (fixes #66 )

Additionally:
- QEMU now starts with `-cpu rv32,pmp=true` flag
- `platform_name` sys config option added
- uart 0 and uart 1 configured for sifive machines (including correct IRQ numbers)
- dts files aded for virt and sifive_u (can't obtain for sifive_e)
- `platform` shell command added