### PR TITLE
improved `idle` and `read_line` functions

### DIFF
--- a/apps/headers/consts.s
+++ b/apps/headers/consts.s
@@ -8,6 +8,7 @@
 .equ SYSFN_RUN, 3
 .equ SYSFN_EXIT, 4
 .equ SYSFN_GET_CFG, 5
+.equ SYSFN_GET_DRV_CFG, 6
 
 # Time functions
 .equ SYSFN_GET_SECS_FROM_EPOCH, 10

--- a/apps/lib/io.s
+++ b/apps/lib/io.s
@@ -166,13 +166,14 @@ fn read_line
 
     mv s1, a0                          # s1 - pointer to the end of the string
 
-    # li a0, CFG_STD_IN                  # get stdin
-    # syscall SYSFN_GET_CFG
-    # call uart_get_config               # get config of stdin
-    # andi s0, a0, 0b10                  # and check if IRQs are enabled
+    li a0, CFG_STD_IN                  # get stdin
+    syscall SYSFN_GET_CFG
+    syscall SYSFN_GET_DRV_CFG
+    andi s0, a0, 0b10
+
 
 1:
-        # beqz s0, 2f                    # call idle system function if irqs are anbled
+        beqz s0, 2f                    # call idle system function if irqs are anbled
             syscall SYSFN_IDLE
 
 2:

--- a/headers/consts.s
+++ b/headers/consts.s
@@ -1,6 +1,7 @@
 .ifndef __CONSTS_S__
 .equ __CONSTS_S__, 1
 
+#----------------------------------------
 # System functions
 
 .equ SYSFN_SLEEP, 1
@@ -8,6 +9,7 @@
 .equ SYSFN_RUN, 3
 .equ SYSFN_EXIT, 4
 .equ SYSFN_GET_CFG, 5
+.equ SYSFN_GET_DRV_CFG, 6
 
 # Time functions
 .equ SYSFN_GET_SECS_FROM_EPOCH, 10
@@ -30,6 +32,8 @@
 
 .equ SYSFN_LAST_FN_ID, 43
 
+
+#----------------------------------------
 # Error Codes
 
 .equ NUM_OF_ERRORS, 6                  # number of error codes
@@ -42,6 +46,7 @@
 .equ ERR_STACK_OVERFLOW, 5
 
 
+#----------------------------------------
 # SYSTEM CONFIG
 
 .equ INFO_OUTPUT_DEV, 0
@@ -52,11 +57,14 @@
 .equ CFG_PLATFORM_NAME, 20
 
 
+#----------------------------------------
 # HAL
 
 .equ DRV_UART_STRUCT_SIZE, 16
 .equ DRV_RTC_STRUCT_SIZE, 8
 
+
+#----------------------------------------
 # DEVICE MANAGER
 
 .equ DEV_MAX_DEVICES_NO, 16

--- a/src/drivers/uart_ns16550a.s
+++ b/src/drivers/uart_ns16550a.s
@@ -38,9 +38,9 @@
 fn ns16550a_init
 
     .set BASE, 0
-    .set GETC, 4
-    .set PUTC, 8
-    .set CONFIG_FN, 12
+    .set GETC, 8
+    .set PUTC, 12
+    .set CONFIG_FN, 4
 
     stack_alloc
     push a2, 8

--- a/src/drivers/uart_sifive.s
+++ b/src/drivers/uart_sifive.s
@@ -26,9 +26,9 @@
 #     a3 - IRQ id
 fn sifive_uart_init
     .set BASE, 0
-    .set GETC, 4
-    .set PUTC, 8
-    .set CONFIG_FN, 12
+    .set GETC, 8
+    .set PUTC, 12
+    .set CONFIG_FN, 4
 
     stack_alloc
     push a2, 8

--- a/src/hal/hal_common.s
+++ b/src/hal/hal_common.s
@@ -1,0 +1,47 @@
+# Common functions for all HAL drivers
+# author: David de Rosier
+# https://github.com/ddrcode/riscv-os
+#
+# See LICENSE file for license details.
+
+.include "macros.s"
+
+.global hal_get_config
+.global hal_set_config
+
+.section .text
+
+fn hal_get_config
+    stack_alloc
+    mv t0, a0
+    lw a0, (t0)
+    mv a1, zero
+    mv a2, zero
+    lw t1, 4(t0)
+    jalr t1
+    stack_free
+    ret
+endfn
+
+
+# Set's driver's configuration
+# Example (enabling uart, but disabling IRQs)
+#    la a0, UART0
+#    li a1, 0b11
+#    li a2, 0b01
+#    call uart_set_config
+# Arguments:
+#     a0 - pointer to uart structure
+#     a1 - configuration mask
+#     a2 - configuration flags
+# Returns: a0 - new configuration
+fn hal_set_config
+    stack_alloc
+    mv t0, a0
+    lw a0, (t0)
+    lw t1, 4(t0)
+    jalr t1
+    stack_free
+    ret
+endfn
+

--- a/src/hal/rtc.s
+++ b/src/hal/rtc.s
@@ -7,7 +7,8 @@
 # RTC Structure
 # byte    size    name
 #    0       4    device id (actually base address)
-#    4       4    u32 get_secs_from_epoch()
+#    4       4    u32 config (u32 base addr, u32 mask, u32 flags)
+#    8       4    u32 get_secs_from_epoch()
 
 .include "macros.s"
 
@@ -20,7 +21,7 @@ fn rtc_get_secs_from_epoch
 
     mv t0, a0
     lw a0, (t0)
-    lw t1, 4(t0)
+    lw t1, 8(t0)
     jalr t1
 
     stack_free

--- a/src/hal/uart.s
+++ b/src/hal/uart.s
@@ -1,9 +1,9 @@
 # UART Structure
 # byte    size    name
 #    0       4    device id (actually UART base)
-#    4       4    u32 putc(u32 base_addr, char c)
-#    8       4    byte getc(u32 base_addr)
-#   12       4    byte config(u32 base_addr, byte mask, byte val)
+#    4       4    byte config(u32 base_addr, byte mask, byte val)
+#    8       4    u32 putc(u32 base_addr, char c)
+#   12       4    byte getc(u32 base_addr)
 #
 # Configuration
 #  bit     name
@@ -28,7 +28,7 @@ fn uart_putc
     stack_alloc
     mv t0, a0
     lw a0, (t0)
-    lw t1, 4(t0)
+    lw t1, 8(t0)
     jalr t1
     stack_free
     ret
@@ -50,7 +50,7 @@ fn uart_puts
     mv a0, s0
     lbu a1, (s1)                       # Get byte at current string pos
     beqz a1, 3f                        # Is null?
-        lw t1, 4(s0)
+        lw t1, 8(s0)
         call uart_putc                 # No, write byte to port
         inc s1                         # Inc string pos
         j 1b                           # Loop
@@ -65,42 +65,6 @@ fn uart_puts
 endfn
 
 fn uart_getc
-    stack_alloc
-    mv t0, a0
-    lw a0, (t0)
-    lw t1, 8(t0)
-    jalr t1
-    stack_free
-    ret
-endfn
-
-# Returns configuration
-# Arguments: a0 - pointer to uart structure
-# Returns: a0 - configuration
-fn uart_get_config
-    stack_alloc
-    mv t0, a0
-    lw a0, (t0)
-    mv a1, zero
-    mv a2, zero
-    lw t1, 12(t0)
-    jalr t1
-    stack_free
-    ret
-endfn
-
-# Returns configuration
-# Example (enabling uart, but disabling IRQs)
-#    la a0, UART0
-#    li a1, 0b11
-#    li a2, 0b01
-#    call uart_set_config
-# Arguments:
-#     a0 - pointer to uart structure
-#     a1 - configuration mask
-#     a2 - configuration flags
-# Returns: a0 - new configuration
-fn uart_set_config
     stack_alloc
     mv t0, a0
     lw a0, (t0)

--- a/src/platforms/sifive_e.s
+++ b/src/platforms/sifive_e.s
@@ -25,7 +25,7 @@ fn platform_start
     la a0, drv_uart_0                  # Configure UART0
     mv s1, a0
     li a1, UART_0_BASE
-    li a2, 0b11                        # IRQ enabled
+    li a2, 0b01                        # IRQ enabled
     li a3, UART_0_IRQ
     call sifive_uart_init
 

--- a/src/sysfn.s
+++ b/src/sysfn.s
@@ -80,6 +80,15 @@ fn sysfn_idle
 endfn
 
 
+fn sysfn_get_drv_config
+    stack_alloc
+    call hal_get_config
+    mv a5, zero
+    stack_free
+    ret
+endfn
+
+
 fn sysfn_get_secs_from_epoch
     stack_alloc
     li a0, DEV_RTC_0
@@ -173,7 +182,7 @@ sysfn_vector:
     .word    sysfn_run                 #  3
     .word    sysfn_exit                #  4
     .word    cfg_get                   #  5
-    .word    0                         #  6
+    .word    sysfn_get_drv_config      #  6
     .word    0                         #  7
     .word    0                         #  8
     .word    0                         #  9


### PR DESCRIPTION
- the `read_line` function can now idle between interrupts, when interrupts for stdin are enabled 
- the `idle` function got extended to ignore exceptions and timer interrupts (adds to #81 )